### PR TITLE
YAMLDecodeFunc: handle null values correctly

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -62,8 +62,8 @@ func (c *Converter) Marshal(v cty.Value) ([]byte, error) {
 // and attempts to convert it into a value conforming to the given type
 // constraint.
 //
-// An error is returned if the given source contains any YAML document
-// delimiters.
+// An error is returned if the given source contains more than one YAML
+// document.
 func (c *Converter) Unmarshal(src []byte, ty cty.Type) (cty.Value, error) {
 	return c.unmarshal(src, ty)
 }

--- a/cty_funcs.go
+++ b/cty_funcs.go
@@ -25,9 +25,6 @@ var YAMLDecodeFunc = function.New(&function.Spec{
 		return Standard.ImpliedType([]byte(args[0].AsString()))
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		if retType == cty.DynamicPseudoType {
-			return cty.DynamicVal, nil
-		}
 		return Standard.Unmarshal([]byte(args[0].AsString()), retType)
 	},
 })

--- a/cty_funcs_test.go
+++ b/cty_funcs_test.go
@@ -8,14 +8,36 @@ import (
 
 func TestYAMLDecodeFunc(t *testing.T) {
 	// FIXME: This is not a very extensive test.
-	got, err := YAMLDecodeFunc.Call([]cty.Value{
-		cty.StringVal("true"),
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	tests := map[string]struct {
+		input string
+		want  cty.Value
+	}{
+		"only document separator": {
+			`---`,
+			cty.NullVal(cty.DynamicPseudoType),
+		},
+		"null": {
+			`~`,
+			cty.NullVal(cty.DynamicPseudoType),
+		},
+		"boolean true": {
+			`true`,
+			cty.True,
+		},
 	}
-	if want := cty.True; !want.RawEquals(got) {
-		t.Fatalf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := YAMLDecodeFunc.Call([]cty.Value{
+				cty.StringVal(test.input),
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if want := test.want; !want.RawEquals(got) {
+				t.Fatalf("wrong result\ngot:  %#v\nwant: %#v", got, want)
+			}
+		})
 	}
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -14,6 +14,34 @@ func TestUnmarshal(t *testing.T) {
 		want      cty.Value
 		wantErr   string
 	}{
+		"only document separator": {
+			Standard,
+			`---`,
+			cty.String,
+			cty.NullVal(cty.String),
+			``,
+		},
+		"null": {
+			Standard,
+			`~`,
+			cty.String,
+			cty.NullVal(cty.String),
+			``,
+		},
+		"one document separator followed by value": {
+			Standard,
+			"---\ntrue",
+			cty.Bool,
+			cty.True,
+			``,
+		},
+		"multiple documents": {
+			Standard,
+			"---\ntrue\n---\nfalse",
+			cty.Bool,
+			cty.DynamicVal,
+			`on line 2, column 1: unexpected extra content after value`,
+		},
 		"single string doublequote": {
 			Standard,
 			`"hello"`,

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/zclconf/go-cty-yaml
 
+go 1.17
+
 require github.com/zclconf/go-cty v1.0.0
+
+require golang.org/x/text v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
@@ -14,5 +12,4 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/implied_type_test.go
+++ b/implied_type_test.go
@@ -13,6 +13,18 @@ func TestImpliedType(t *testing.T) {
 		want      cty.Type
 		wantErr   string
 	}{
+		"only document separator": {
+			Standard,
+			`---`,
+			cty.DynamicPseudoType, // would decode as a null value of unknown type
+			``,
+		},
+		"null": {
+			Standard,
+			`~`,
+			cty.DynamicPseudoType, // would decode as a null value of unknown type
+			``,
+		},
 		"single string doublequote": {
 			Standard,
 			`"hello"`,


### PR DESCRIPTION
Due to a logic error in the `YAMLDecodeFunc` implementation, any situation where the result was literally null the function would return an unknown value of an unknown type instead.

Now it will correctly return a null of unknown type instead.

This also includes some extra test coverage for other functions to confirm that they were already handling these situations correctly, and to guard against possible future regressions for these edge-cases.

This was originally reported in the repository of a downstream user of this library: https://github.com/hashicorp/terraform/issues/31188 .