### PR TITLE
Fixing decode error of + strings (plus sign)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* The YAML decoder now exactly follows the [YAML specification](https://yaml.org/spec/1.2-old/spec.html#id2805071) when parsing integers.
+  **Note:** This removes support for `_` spaces as well as signed base8 and base16 values.
+
 # 1.0.3 (November 2, 2022)
 
 * The `YAMLDecodeFunc` cty function now correctly handles both entirely empty

--- a/decode_test.go
+++ b/decode_test.go
@@ -105,6 +105,13 @@ func TestUnmarshal(t *testing.T) {
 			cty.StringVal("hello"),
 			``,
 		},
+		"single string plus sign only": {
+			Standard,
+			`+`,
+			cty.String,
+			cty.StringVal("+"),
+			``,
+		},
 		"single string implied not merge": {
 			Standard,
 			`<<`,

--- a/decode_test.go
+++ b/decode_test.go
@@ -231,20 +231,6 @@ func TestUnmarshal(t *testing.T) {
 			cty.NumberIntVal(31),
 			``,
 		},
-		"single hexadecimal int negative implied by parsability": {
-			Standard,
-			`-0x1f`,
-			cty.Number,
-			cty.NumberIntVal(-31),
-			``,
-		},
-		"single hexadecimal int with underscores implied by parsability": {
-			Standard,
-			`0x0000_0000_ffff_0000`,
-			cty.Number,
-			cty.NumberIntVal(4294901760),
-			``,
-		},
 		"single string which looks like a binary number": {
 			Standard,
 			`0ba`,

--- a/implied_type_test.go
+++ b/implied_type_test.go
@@ -43,6 +43,12 @@ func TestImpliedType(t *testing.T) {
 			cty.String,
 			``,
 		},
+		"single string plus sign only": {
+			Standard,
+			`+`,
+			cty.String,
+			``,
+		},
 		"single string implied not merge": {
 			Standard,
 			`<<`,

--- a/resolve.go
+++ b/resolve.go
@@ -27,7 +27,7 @@ var integerLiteralRegexp = regexp.MustCompile(`` +
 	// start of string, optional sign, and one of:
 	`\A[-+]?(` +
 	// octal literal with 0o prefix and optional _ spaces
-	`|0o[0-7_]+` +
+	`0o[0-7_]+` +
 	// decimal literal and optional _ spaces
 	`|[0-9_]+` +
 	// hexadecimal literal with 0x prefix and optional _ spaces

--- a/resolve.go
+++ b/resolve.go
@@ -24,14 +24,14 @@ var resolveMap = make(map[string]resolveMapItem)
 //
 // https://yaml.org/spec/1.2/spec.html#id2805071
 var integerLiteralRegexp = regexp.MustCompile(`` +
-	// start of string, optional sign, and one of:
-	`\A[-+]?(` +
-	// octal literal with 0o prefix and optional _ spaces
-	`0o[0-7_]+` +
-	// decimal literal and optional _ spaces
-	`|[0-9_]+` +
-	// hexadecimal literal with 0x prefix and optional _ spaces
-	`|0x[0-9a-fA-F_]+` +
+	// start of string and one of:
+	`\A(` +
+	// base10
+	`[-+]?[0-9]+` +
+	// base8
+	`|0o[0-7]+` +
+	// base16
+	`|0x[0-9a-fA-F]+` +
 	// end of group, and end of string
 	`)\z`,
 )


### PR DESCRIPTION
Fix for #13

The first regex OR (now removed) caused regex to pass even if none of the succeeding oct|dec|hex definitions was present.

Quite confident this fixes it:
* Testsuite contains tests for oct|dec|hex (`decode_test.go`)
* No unexpected side-effects in testsuite 
